### PR TITLE
Upgrade to duplicity 0.7.06

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 #
 
 # URL for the duplicity source
-default['duplicity']['src_url'] = 'http://code.launchpad.net/duplicity/0.6-series/0.6.23/+download/duplicity-0.6.23.tar.gz'
+default['duplicity']['src_url'] = 'https://code.launchpad.net/duplicity/0.7-series/0.7.06/+download/duplicity-0.7.06.tar.gz'
 
 # local directory to place the source in
 default['duplicity']['src_dir'] = '/usr/local/src'

--- a/recipes/install_duplicity.rb
+++ b/recipes/install_duplicity.rb
@@ -45,7 +45,7 @@ remote_file src_path do
 end
 
 # Always build if the executable isn't there - could be a previous failed provision
-default_action = Kernel.system('which duplicity') ? :nothing : :run
+default_action = Kernel.system('which duplicity > /dev/null') ? :nothing : :run
 unpack_dir_name = File.basename(src_name, '.tar.gz')
 
 execute "install-duplicity" do

--- a/spec/install_duplicity_spec.rb
+++ b/spec/install_duplicity_spec.rb
@@ -74,7 +74,7 @@ describe 'duplicity-backup::install_duplicity' do
   
   context "when the source is unchanged and the executable is present" do
     before(:each) do
-      Kernel.stub(:system).with('which duplicity').and_return(true)
+      Kernel.stub(:system).with('which duplicity > /dev/null').and_return(true)
     end
 
     it "does not attempt to unpack and build the source" do
@@ -84,7 +84,7 @@ describe 'duplicity-backup::install_duplicity' do
   
   context "when the duplicity executable is not present even if the source is unchanged" do
     before(:each) do
-      Kernel.stub(:system).with('which duplicity').and_return(false)
+      Kernel.stub(:system).with('which duplicity > /dev/null').and_return(false)
     end
     
     it "compiles and installs from source" do

--- a/templates/default/backup.sh.erb
+++ b/templates/default/backup.sh.erb
@@ -96,7 +96,7 @@ echo "Backing up files"
           --s3-use-new-style \
           <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
           --name file_backup \
-          --include-globbing-filelist /etc/duplicity/globbing_file_list \
+          --include-filelist /etc/duplicity/globbing_file_list \
           --exclude '**' \
           / \
           "<%=node['duplicity']['file_destination'] %>"


### PR DESCRIPTION
Includes resolution for the invalid man-db permissions that were set as part of the 0.6.x install, and use of the --include-filelist rather than --include-globbing-filelist which is now deprecated.

For full duplicity changes see the duplicity changelog at http://duplicity.nongnu.org/CHANGELOG