### PR TITLE
[BREAKING] Update to use latest version of database cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* [BREAKING] Update to latest version of the database cookbook - note you
+  *must* now install the mysql2_chef_gem yourself before use - this is no
+  longer handled by this cookbook to minimise hard dependencies. See the 
+  README.
+
 ## 1.1.3 / 2016-09-07
 
 * [DEV] Update chefspec/chef dependencies and specs to resolve deprecation

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ Have your main project cookbook *depend* on duplicity-backup by editing the `met
 depends 'duplicity-backup'
 ```
 
+If you want to backup a mysql database, you will also need to install the `mysql2` gem - 
+to allow the cookbook to manage users - this is not handled by the cookbook.
+
+You can do this by depending on the `mysql2_chef_gem` cookbook and adding the following 
+resource definition to a recipe of your own:
+
+```ruby
+# Your own recipe, called before referencing duplicity-backup
+mysql2_chef_gem 'default' do
+  action :install
+end
+```
+
 Usage
 -----
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,5 @@ source_url 'https://github.com/ingenerator/chef-duplicity-backup'
 end
 
 depends 'python'
-depends 'database',   '~> 2.3.1'
-depends 'mysql',      '~> 5.6.1'
+depends 'database', '~> 5.1'
 depends 'postgresql'

--- a/recipes/backup_mysql_user.rb
+++ b/recipes/backup_mysql_user.rb
@@ -21,10 +21,8 @@
 #
 
 if node['duplicity']['backup_mysql'] then
-  
-  include_recipe('database::mysql')
-  
-  root_connection = { 
+
+  root_connection = {
     :host     => 'localhost', 
     :username => 'root', 
     :password => node['mysql']['server_root_password'] 

--- a/spec/backup_mysql_user_spec.rb
+++ b/spec/backup_mysql_user_spec.rb
@@ -11,11 +11,7 @@ describe 'duplicity-backup::backup_mysql_user' do
         node.normal['mysql']['server_root_password'] = 'mysql'
       end.converge(described_recipe)
     end
-    
-    it "should include the database::mysql recipe" do
-      expect(chef_run).to include_recipe('database::mysql')
-    end
-    
+
     it "should create a database user for backups" do
       expect(chef_run).to grant_mysql_database_user('backup')
     end


### PR DESCRIPTION
We can also drop the dependency on the mysql cookbook, which isn't
actually used.
