### PR TITLE
Refactor generating backup commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Berksfile.lock
+.bundle/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Extracted backup command generation from the template to a custom helper, 
+  and refactored specs for the configure_backup recipe to stub the helper
+  and reflect the new responsibilities. This allows for clearer and more
+  rigorous specification of individual commands rather than having all the
+  logic in the template rendering
 * Some internal refactoring of specs for speed and legibility
 * Update to duplicity 0.7.13.1
 * Update to poise-python 1.6 for Chef 13 support

--- a/libraries/attribute_helper.rb
+++ b/libraries/attribute_helper.rb
@@ -1,0 +1,32 @@
+module Ingenerator
+  module DuplicityBackup
+
+    ##
+    # Thrown if one or more config variables for a given backup aren't present
+    # or have empty values.
+    # - eg the backup destination for a given backup is not set
+    #
+    class IncompleteConfigError < RuntimeError
+      def initialize(attr_path)
+        super "You must specify a value for node.#{attr_path}"
+      end
+    end
+
+    ##
+    # Get the value of an attribute from .-separated path, throw if missing
+    #
+    # @param [String] dot-separated path to node attribute required
+    # @return [String]
+    #
+    def self.require_attribute!(node, attribute_path)
+      keys = attribute_path.split('.')
+      value = keys.inject(node.attributes) do |attributes, key|
+        attributes[key] if attributes && attributes.key?(key)
+      end
+
+      raise IncompleteConfigError, attribute_path unless value
+      value
+    end
+
+  end
+end

--- a/libraries/command_builder.rb
+++ b/libraries/command_builder.rb
@@ -1,0 +1,219 @@
+# Helper to robustly build the various shell commands required to run the backup
+# This isn't my favourite work, but it works in the context of the existing cookbook
+module Ingenerator
+  module DuplicityBackup
+    ##
+    # Thrown if attempting to generate commands for a backup that isn't enabled.
+    # This is generally a cookbook-level logic error.
+    #
+    class BackupNotEnabledError < RuntimeError
+      def initialize(attr_path)
+        super "Attempted to build commands for a backup that is not enabled (set node.#{attr_path} = true)"
+      end
+    end
+
+    ##
+    # Thrown if one or more config variables for a given backup aren't present
+    # or have empty values.
+    # - eg the backup destination for a given backup is not set
+    #
+    class IncompleteConfigError < RuntimeError
+      def initialize(attr_path)
+        super "You must specify a value for node.#{attr_path}"
+      end
+    end
+
+    ##
+    # Thrown if attempting to generate commands for an undefined backup job name
+    # Currently the available jobs are hardcoded in the cookbook, so this is an
+    # internal logic error, or an attempt to use the library in an unsupported
+    # way.
+    class UnknownBackupError < ArgumentError
+      def initialize(backup_name)
+        super "Backup job #{backup_name} is not defined in this cookbook"
+      end
+    end
+
+    ##
+    # Builds executable commands, with their arguments, for the various stages
+    # of the backup.
+    class CommandBuilder
+      def initialize(node)
+        @node = node
+      end
+
+      ##
+      # Generate command to mysqldump a single schema to a dump file
+      #
+      # @param [String] the shell variable pointing to the schema to backup
+      # @param [String] the shell variable pointing to the output dump file
+      # @return [String]
+      #
+      def mysqldump(db_var, output_path_var)
+        raise BackupNotEnabledError, 'duplicity.backup_mysql' unless @node['duplicity']['backup_mysql']
+
+        format_command(
+          [
+            'mysqldump --defaults-file=/etc/duplicity/mysql.cnf',
+            '$SCHEMA_BACKUP_FLAGS',
+            '-h localhost',
+            @node['duplicity']['mysql']['innodb_only'] ? '--single-transaction' : '',
+            '"' + db_var + '" | gzip -9 > "' + output_path_var + '"'
+          ]
+        )
+      end
+
+      ##
+      # Generate command to dump a full postgresql database to an output file
+      #
+      # @param [String] the shell variable pointing to the output file
+      # @return [String]
+      #
+      def pg_dumpall(output_path_var)
+        raise BackupNotEnabledError, 'duplicity.backup_postgresql' unless @node['duplicity']['backup_postgresql']
+        user = require_attribute! 'duplicity.postgresql.user'
+        host = require_attribute! 'duplicity.postgresql.host'
+
+        format_command(
+          [
+            'PGPASSFILE="/etc/duplicity/.pgpass" pg_dumpall',
+            "-h#{host}",
+            "-U#{user}",
+            '| gzip -9 > "' + output_path_var + '"'
+          ]
+        )
+      end
+
+      ##
+      # Generate command to backup an entire directory as a remote backup
+      # - used primarily for database dumps
+      #
+      # @param [String] shell variable pointing to the source directory
+      # @param [String] name of the backup job, internally mapped to a destination
+      # @return [String]
+      #
+      def duplicity_backup_dir(from_dir, backup_name)
+        duplicity_backup_cmd(
+          from_dir,
+          backup_name,
+          ['--allow-source-mismatch']
+        )
+      end
+
+      ##
+      # Generate command to backup a partial filelist, all relative to the /,
+      # as the file_backup job (to the file_destination)
+      #
+      # @return [String]
+      #
+      def duplicity_backup_filelist
+        duplicity_backup_cmd(
+          '/',
+          'file_backup',
+          [
+            '--include-filelist /etc/duplicity/globbing_file_list',
+            '--exclude \'**\''
+          ]
+        )
+      end
+
+      ##
+      # Generate command to cleanup old full backups for any known job
+      #
+      # @param [String] name of the backup job, internally mapped to a destination
+      # @return [String]
+      #
+      def duplicity_remove_all_but_n_full(backup_name)
+        keep_n_full = require_attribute!('duplicity.keep_n_full').to_s
+        parts = [
+          "/usr/local/bin/duplicity remove-all-but-n-full #{keep_n_full}",
+          '--force',
+          "--name #{backup_name}"
+        ]
+        parts.concat(duplicity_s3_options)
+        parts.push('"' + job_destination(backup_name) + '"')
+        format_command(parts)
+      end
+
+      private
+
+      ##
+      # Format a command from parts to a multi-line indented command and arguments
+      #
+      # @param [Array<String>] individual lines of the command
+      # @return [String]
+      #
+      def format_command(parts)
+        parts.reject(&:empty?).join(" \\\n  ")
+      end
+
+      ##
+      # Get the configured destination of a known job, or throw
+      #
+      # @param [String] backup job name
+      # @return [String] S3 bucket job destination
+      #
+      def job_destination(backup_name)
+        attr_name = {
+          'mysql_backup' => 'duplicity.db_destination',
+          'pg_backup'    => 'duplicity.pg_destination',
+          'file_backup'  => 'duplicity.file_destination'
+        }[backup_name]
+
+        raise UnknownBackupError, backup_name unless attr_name
+        require_attribute! attr_name
+      end
+
+      ##
+      # Get the value of an attribute from .-separated path, throw if missing
+      #
+      # @param [String] dot-separated path to node attribute required
+      # @return [String]
+      #
+      def require_attribute!(attribute_path)
+        keys = attribute_path.split('.')
+        value = keys.inject(@node.attributes) do |attributes, key|
+          attributes[key] if attributes && attributes.key?(key)
+        end
+
+        raise IncompleteConfigError, attribute_path unless value
+        value
+      end
+
+      ##
+      # Build a generic duplicity backup command with extra parts provided
+      #
+      # @param [String] base directory to backup from
+      # @param [String] internal backup job name to map to destination
+      # @param [Array<String>] extra arguments / options
+      # @return [String]
+      #
+      def duplicity_backup_cmd(source_path, backup_name, extra_options)
+        full_if_older_than = require_attribute!('duplicity.full_if_older_than')
+        parts = [
+          '/usr/local/bin/duplicity',
+          "--full-if-older-than #{full_if_older_than}",
+          "--name #{backup_name}"
+        ]
+        parts.concat(duplicity_s3_options)
+        parts.concat(extra_options)
+        parts.push('"' + source_path + '"')
+        parts.push('"' + job_destination(backup_name) + '"')
+        format_command(parts)
+      end
+
+      ##
+      # The S3-related command options relevant to all duplicity commands
+      #
+      # @return [String]
+      #
+      def duplicity_s3_options
+        options = ['--s3-use-new-style']
+        if @node['duplicity']['s3-european-buckets']
+          options << '--s3-european-buckets'
+        end
+        options
+      end
+    end
+  end
+end

--- a/libraries/command_builder.rb
+++ b/libraries/command_builder.rb
@@ -13,17 +13,6 @@ module Ingenerator
     end
 
     ##
-    # Thrown if one or more config variables for a given backup aren't present
-    # or have empty values.
-    # - eg the backup destination for a given backup is not set
-    #
-    class IncompleteConfigError < RuntimeError
-      def initialize(attr_path)
-        super "You must specify a value for node.#{attr_path}"
-      end
-    end
-
-    ##
     # Thrown if attempting to generate commands for an undefined backup job name
     # Currently the available jobs are hardcoded in the cookbook, so this is an
     # internal logic error, or an attempt to use the library in an unsupported
@@ -171,13 +160,7 @@ module Ingenerator
       # @return [String]
       #
       def require_attribute!(attribute_path)
-        keys = attribute_path.split('.')
-        value = keys.inject(@node.attributes) do |attributes, key|
-          attributes[key] if attributes && attributes.key?(key)
-        end
-
-        raise IncompleteConfigError, attribute_path unless value
-        value
+        Ingenerator::DuplicityBackup.require_attribute! @node, attribute_path
       end
 
       ##
@@ -214,6 +197,8 @@ module Ingenerator
         end
         options
       end
-    end
+    end unless defined?(Ingenerator::DuplicityBackup::CommandBuilder)
+    # The conditional declaration is required so that chef doesn't overwrite the
+    # class during converge if we've already stubbed it from chefspec
   end
 end

--- a/recipes/configure_backup.rb
+++ b/recipes/configure_backup.rb
@@ -20,26 +20,17 @@
 # limitations under the License.
 #
 
-# Validate the attributes
-required_attributes = %w{ backup_passphrase file_destination keep_n_full full_if_older_than }
+# Validate the attributes (most are now validated in the CommandBuilder helpers)
+Ingenerator::DuplicityBackup.require_attribute!(node, 'duplicity.backup_passphrase')
+
 if node['duplicity']['backup_mysql'] then
-  required_attributes << 'db_destination'
-
-  %w{ user password }.each do | key |
-    raise ArgumentError, "You must set node['duplicity']['mysql']['#{key}']" unless node['duplicity']['mysql'][key]
-  end
-
+  Ingenerator::DuplicityBackup.require_attribute!(node, 'duplicity.mysql.user')
+  Ingenerator::DuplicityBackup.require_attribute!(node, 'duplicity.mysql.password')
 end
+
 if node['duplicity']['backup_postgresql'] then
-  required_attributes << 'pg_destination'
-
-  %w{ user password }.each do | key |
-    raise ArgumentError, "You must set node['duplicity']['postgresql']['#{key}']" unless node['duplicity']['postgresql'][key]
-  end
-
-end
-required_attributes.each do | key |
-  raise ArgumentError, "You must set node['duplicity']['#{key}']" unless node['duplicity'][key]
+  Ingenerator::DuplicityBackup.require_attribute!(node, 'duplicity.postgresql.user')
+  Ingenerator::DuplicityBackup.require_attribute!(node, 'duplicity.postgresql.password')
 end
 
 node['duplicity']['globbing_file_patterns'].each do | pattern, is_active |

--- a/recipes/configure_backup.rb
+++ b/recipes/configure_backup.rb
@@ -72,6 +72,9 @@ template "/etc/duplicity/backup.sh" do
   mode   0744
   owner  "root"
   group  "root"
+  variables({
+    commands: Ingenerator::DuplicityBackup::CommandBuilder.new(node)
+  })
 end
 
 # Environment variables to provide to duplicity (eg AWS keys)

--- a/spec/libraries/command_builder_spec.rb
+++ b/spec/libraries/command_builder_spec.rb
@@ -1,0 +1,310 @@
+require 'spec_helper'
+require_relative '../../libraries/command_builder.rb'
+
+describe Ingenerator::DuplicityBackup::CommandBuilder do
+  let(:node)     { Chef::Node.new }
+  let(:subject)  { Ingenerator::DuplicityBackup::CommandBuilder.new(node) }
+  let(:commands) { Ingenerator::DuplicityBackup::CommandBuilder.new(node) }
+
+  before(:each) do
+    node.normal['duplicity'] = {}
+    node.normal['duplicity']['mysql'] = {}
+  end
+
+  shared_examples 'duplicity command with common s3 options' do
+    it 'uses new-style s3 buckets' do
+      expect_valid_command(subject).to include ' --s3-use-new-style '
+    end
+
+    it 'does not use s3-european-buckets if not in node attributes' do
+      node.normal['duplicity']['s3-european-buckets'] = false
+      expect_valid_command(subject).not_to include '--s3-european-buckets'
+    end
+
+    it 'uses s3-european-buckets if configured in node attributes' do
+      node.normal['duplicity']['s3-european-buckets'] = true
+      expect_valid_command(subject).to include '--s3-european-buckets'
+    end
+  end
+
+  shared_examples 'basic duplicity backup command' do |expect_source|
+    context 'with invalid configuration' do
+      it 'fails if there is no destination for the backup name' do
+        node.rm('duplicity', dest_attr)
+        expect { subject }.to raise_error(Ingenerator::DuplicityBackup::IncompleteConfigError, /node.duplicity.\w+_destination/)
+      end
+
+      it 'fails if full_if_older_than not specified' do
+        node.rm('duplicity', 'full_if_older_than')
+        expect { subject }.to raise_error(Ingenerator::DuplicityBackup::IncompleteConfigError, /node.duplicity.full_if_older_than/)
+      end
+    end
+
+    context 'with valid config' do
+      it 'produces a duplicity backup command' do
+        expect_valid_command(subject).to start_with '/usr/local/bin/duplicity'
+      end
+
+      it 'specifies the expected full_if_older_than value' do
+        node.normal['duplicity']['full_if_older_than'] = '15D'
+        expect_valid_command(subject).to include ' --full-if-older-than 15D '
+      end
+
+      it_behaves_like 'duplicity command with common s3 options'
+
+      it 'specifies the backup name' do
+        expect_valid_command(subject).to include " --name #{backup_name} "
+      end
+
+      it 'specifies the expected backup source directory' do
+        expect_valid_command(subject).to include ' "' + expect_source + '" \\'
+      end
+
+      it 'specifies the expected backup destination' do
+        node.normal['duplicity'][dest_attr] = 's3://some.bucket/path'
+        expect_valid_command(subject).to end_with ' "s3://some.bucket/path"'
+      end
+    end
+  end
+
+  shared_examples 'remove_all_but_n_full for known backup' do
+    context 'with invalid configuration' do
+      it 'fails if there is no destination for the backup name' do
+        node.rm('duplicity', dest_attr)
+        expect { subject }.to raise_error(Ingenerator::DuplicityBackup::IncompleteConfigError, /node.duplicity.\w+_destination/)
+      end
+
+      it 'fails if keep_n_full is not configured' do
+        node.rm('duplicity', 'keep_n_full')
+        expect { subject }.to raise_error(Ingenerator::DuplicityBackup::IncompleteConfigError, /node.duplicity.keep_n_full/)
+      end
+    end
+
+    context 'with minimum valid configuration' do
+      before(:each) do
+        node.normal['duplicity']['keep_n_full'] = 5
+        node.normal['duplicity'][dest_attr] = 's3://my.bucket/path'
+      end
+
+      it 'produces a duplicity remove-all-but-n-full command with expected number' do
+        expect_valid_command(subject).to start_with '/usr/local/bin/duplicity remove-all-but-n-full 5 '
+      end
+
+      it 'forces the removal' do
+        expect_valid_command(subject).to include ' --force '
+      end
+
+      it 'specifies the backup name' do
+        expect_valid_command(subject).to include " --name #{backup_name} "
+      end
+
+      it 'specifies the expected db backup destination' do
+        node.normal['duplicity'][dest_attr] = 's3://some.bucket/path'
+        expect_valid_command(subject).to end_with ' "s3://some.bucket/path"'
+      end
+
+      it_behaves_like 'duplicity command with common s3 options'
+    end
+  end
+
+  shared_examples 'backup_dir for known backup' do
+    before(:each) do
+      node.normal['duplicity']['full_if_older_than'] = '3D'
+      node.normal['duplicity'][dest_attr] = 's3://a.bucket'
+    end
+
+    it_behaves_like 'basic duplicity backup command', '$anywhere'
+
+    it 'allows source mismatch' do
+      expect_valid_command(subject).to include ' --allow-source-mismatch '
+    end
+  end
+
+  describe '#duplicity_backup_dir' do
+    let(:from_dir) { '$anywhere' }
+    let(:subject)  { commands.duplicity_backup_dir(from_dir, backup_name) }
+
+    before(:each) do
+      node.normal['duplicity']['full_if_older_than'] = '5D'
+    end
+
+    context 'with unknown backup name' do
+      let(:backup_name) { 'unspecified' }
+
+      it 'throws an exception' do
+        expect { subject }.to raise_error Ingenerator::DuplicityBackup::UnknownBackupError
+      end
+    end
+
+    context 'for mysql_backup' do
+      let(:backup_name) { 'mysql_backup' }
+      let(:dest_attr)   { 'db_destination' }
+
+      it_behaves_like 'backup_dir for known backup'
+    end
+
+    context 'for pg_backup' do
+      let(:backup_name) { 'pg_backup' }
+      let(:dest_attr)   { 'pg_destination' }
+
+      it_behaves_like 'backup_dir for known backup'
+    end
+  end
+
+  describe '#duplicity_backup_filelist' do
+    let(:subject)     { commands.duplicity_backup_filelist }
+    let(:backup_name) { 'file_backup' }
+    let(:dest_attr)   { 'file_destination' }
+
+    before(:each) do
+      node.normal['duplicity']['full_if_older_than'] = '3D'
+      node.normal['duplicity'][dest_attr] = 's3://a.bucket'
+    end
+
+    it 'does not allow source mismatch' do
+      expect_valid_command(subject).not_to include ' --allow-source-mismatch '
+    end
+
+    it 'includes the reference to the globbing file list' do
+      expect_valid_command(subject).to include ' --include-filelist /etc/duplicity/globbing_file_list '
+    end
+
+    it 'excludes all files by default' do
+      expect_valid_command(subject).to include " --exclude '**' "
+    end
+
+    it_behaves_like 'basic duplicity backup command', '/'
+  end
+
+  describe '#duplicity_remove_all_but_n_full' do
+    let(:subject) { commands.duplicity_remove_all_but_n_full(backup_name) }
+
+    before(:each) do
+      node.normal['duplicity']['keep_n_full'] = '5D'
+    end
+
+    context 'with unknown backup name' do
+      let(:backup_name) { 'foobar' }
+
+      it 'throws an exception' do
+        expect { subject }.to raise_error Ingenerator::DuplicityBackup::UnknownBackupError
+      end
+    end
+
+    context 'for mysql_backup' do
+      let(:backup_name) { 'mysql_backup' }
+      let(:dest_attr)   { 'db_destination' }
+
+      it_behaves_like 'remove_all_but_n_full for known backup'
+    end
+
+    context 'for pg_backup' do
+      let(:backup_name) { 'pg_backup' }
+      let(:dest_attr)   { 'pg_destination' }
+
+      it_behaves_like 'remove_all_but_n_full for known backup'
+    end
+
+    context 'for file_backup' do
+      let(:backup_name) { 'file_backup' }
+      let(:dest_attr)   { 'file_destination' }
+
+      it_behaves_like 'remove_all_but_n_full for known backup'
+    end
+  end
+
+  describe '#mysqldump' do
+    let(:db_var)     { '$dbname' }
+    let(:output_var) { '$DIR/mysql-$db.sql.gz' }
+    let(:subject)    { commands.mysqldump(db_var, output_var) }
+
+    context 'with invalid configuration' do
+      it 'fails if mysql backup is not enabled' do
+        node.normal['duplicity']['backup_mysql'] = false
+        expect { subject }.to raise_error Ingenerator::DuplicityBackup::BackupNotEnabledError
+      end
+    end
+
+    context 'with minimum valid attributes' do
+      before(:each) do
+        node.normal['duplicity']['backup_mysql'] = true
+      end
+
+      it 'produces a mysqldump command with the expected defaults file' do
+        expect_valid_command(subject).to start_with 'mysqldump --defaults-file=/etc/duplicity/mysql.cnf '
+      end
+
+      it 'dumps the specified database, gzips and sends to output path' do
+        expect_valid_command(subject).to end_with '  "$dbname" | gzip -9 > "$DIR/mysql-$db.sql.gz"'
+      end
+
+      it 'does not include the single transaction flag if innodb_only is cleared' do
+        expect_valid_command(subject).not_to include '--single-transaction'
+      end
+
+      context 'with additional configuration' do
+        it 'backs up in a single transaction if innodb_only set' do
+          node.default['duplicity']['mysql']['innodb_only'] = true
+          expect_valid_command(subject).to include '  --single-transaction '
+        end
+      end
+    end
+  end
+
+  describe '#pg_dumpall' do
+    let(:output_var) { '$SOMEDIR/pgd.sql.gz' }
+    let(:subject)    { commands.pg_dumpall(output_var) }
+
+    before(:each) do
+      node.normal['duplicity']['backup_postgresql']  = true
+      node.normal['duplicity']['postgresql']['user'] = 'fred'
+      node.normal['duplicity']['postgresql']['host'] = 'localhost'
+    end
+
+    context 'with invalid configuration' do
+      it 'fails if postgresql backup is not enabled' do
+        node.normal['duplicity']['backup_postgresql'] = false
+        expect { subject }.to raise_error Ingenerator::DuplicityBackup::BackupNotEnabledError
+      end
+
+      it 'fails if no host is specified' do
+        node.rm('duplicity', 'postgresql', 'host')
+        expect { subject }.to raise_error(Ingenerator::DuplicityBackup::IncompleteConfigError, /node.duplicity.postgresql.host/)
+      end
+
+      it 'fails if no user is specified' do
+        node.rm('duplicity', 'postgresql', 'user')
+        expect { subject }.to raise_error(Ingenerator::DuplicityBackup::IncompleteConfigError, /node.duplicity.postgresql.user/)
+      end
+    end
+
+    context 'with minimum valid attributes' do
+      it 'produces a pgdumpall command with the expected PGPASSFILE' do
+        expect_valid_command(subject).to start_with 'PGPASSFILE="/etc/duplicity/.pgpass" pg_dumpall '
+      end
+
+      it 'specifies the expected host' do
+        node.normal['duplicity']['postgresql']['host'] = '134.142.232.242'
+        expect_valid_command(subject).to include ' -h134.142.232.242 '
+      end
+
+      it 'specifies the expected user' do
+        node.normal['duplicity']['postgresql']['user'] = 'billy'
+        expect_valid_command(subject).to include ' -Ubilly '
+      end
+
+      it 'dumps all databases, gzips and sends to output path' do
+        expect_valid_command(subject).to end_with ' | gzip -9 > "$SOMEDIR/pgd.sql.gz"'
+      end
+    end
+  end
+
+  def expect_valid_command(command)
+    raise "Trailing newline escape in `#{command}`" if /\\\s*\z/ =~ command
+    raise "Unescaped newline in `#{command}`" if /(?<! \\)\n/ =~ command
+    raise "Invalid empty lines in `#{command}`" if /^\s+\\?$/m =~ command
+    raise "Unindented continuation line in `#{command}`" if /\n(?!  )/ =~ command
+
+    expect(command)
+  end
+end

--- a/templates/default/backup.sh.erb
+++ b/templates/default/backup.sh.erb
@@ -37,11 +37,7 @@ do
       SCHEMA_BACKUP_FLAGS=""
     fi
 
-    mysqldump --defaults-file=/etc/duplicity/mysql.cnf \
-              $SCHEMA_BACKUP_FLAGS \
-              -h localhost \
-              <%=node['duplicity']['mysql']['innodb_only'] ? '--single-transaction' : '' %> \
-              "$db" | gzip -9 > "$MYSQLTMPDIR/mysql-$db.sql.gz"
+    <%=@commands.mysqldump('$db', '$MYSQLTMPDIR/mysql-$db.sql.gz') %>
   fi
 done
 if [ -z "$FOUND_DBS" ]; then
@@ -51,74 +47,42 @@ if [ -z "$FOUND_DBS" ]; then
 fi
 
 echo "Backing up mysql database dump"
-/usr/local/bin/duplicity --full-if-older-than <%=node['duplicity']['full_if_older_than'] %> \
-          --s3-use-new-style \
-          <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
-          --name mysql_backup \
-          --allow-source-mismatch \
-          "$MYSQLTMPDIR" \
-          "<%=node['duplicity']['db_destination'] %>"
+<%=@commands.duplicity_backup_dir('$MYSQLTMPDIR', 'mysql_backup') %>
 
 rm -rf "$MYSQLTMPDIR"
 
 echo "Cleaning old mysql full database backups"
-/usr/local/bin/duplicity remove-all-but-n-full <%=node['duplicity']['keep_n_full'] %> \
-          --force \
-          --s3-use-new-style \
-          <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
-          "<%=node['duplicity']['db_destination'] %>"
+<%=@commands.duplicity_remove_all_but_n_full('mysql_backup') %>
 
 <% end %>
 
+<% if node['duplicity']['backup_postgresql'] %>
 ### PostgreSQL backup ###
 
-<% if node['duplicity']['backup_postgresql'] %>
 echo "Creating postgresql database dump"
 
 # Create temp dir that only we can see
 POSTGRESTMPDIR="$(mktemp -d)"
 
-PGPASSFILE="/etc/duplicity/.pgpass" pg_dumpall -h<%=node['duplicity']['postgresql']['host'] %> -U<%=node['duplicity']['postgresql']['user'] %> | gzip -9 > "$POSTGRESTMPDIR/pgdump.sql.gz"
+<%=@commands.pg_dumpall('$POSTGRESTMPDIR/pgdump.sql.gz') %>
 
 echo "Backing up postgresql database dump"
-/usr/local/bin/duplicity --full-if-older-than <%=node['duplicity']['full_if_older_than'] %> \
-          --s3-use-new-style \
-          <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
-          --name pg_backup \
-          --allow-source-mismatch \
-          "$POSTGRESTMPDIR" \
-          "<%=node['duplicity']['pg_destination'] %>"
+<%=@commands.duplicity_backup_dir('$POSTGRESTMPDIR', 'pg_backup') %>
 
 rm -rf "$POSTGRESTMPDIR"
 
 echo "Cleaning old postgresql full database backups"
-/usr/local/bin/duplicity remove-all-but-n-full <%=node['duplicity']['keep_n_full'] %> \
-          --force \
-          --s3-use-new-style \
-          <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
-          "<%=node['duplicity']['pg_destination'] %>"
+<%=@commands.duplicity_remove_all_but_n_full('pg_backup') %>
 
 <% end %>
 
 ### File backup ###
 echo "Backing up files"
-/usr/local/bin/duplicity --full-if-older-than <%=node['duplicity']['full_if_older_than'] %> \
-          --s3-use-new-style \
-          <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
-          --name file_backup \
-          --include-filelist /etc/duplicity/globbing_file_list \
-          --exclude '**' \
-          / \
-          "<%=node['duplicity']['file_destination'] %>"
-
+<%=@commands.duplicity_backup_filelist %>
 
 ### Old backup cleanup ###
 echo "Cleaning old full backups"
-/usr/local/bin/duplicity remove-all-but-n-full <%=node['duplicity']['keep_n_full'] %> \
-          --force \
-          --s3-use-new-style \
-          <%=node['duplicity']['s3-european-buckets'] ? '--s3-european-buckets' : '' %> \
-          "<%=node['duplicity']['file_destination'] %>"
+<%=@commands.duplicity_remove_all_but_n_full('file_backup') %>
 
 echo ":):):):):):):):):):):):):):):):):):):):):):):)"
 echo "Backup Successful"


### PR DESCRIPTION
Rather than compiling the commands from variables inside the template, move them to a standalone helper library of their own. This allows them to be much more robustly specified, so that we can be clearer
about the logic behind each separate command rather than having to parse the full template for each set of variables.