### PR TITLE
[BREAKING] Always backup DBs to same place and don't `--allow-source…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Extracted backup command generation from the template to a custom helper, 
+* [BREAKING] Disable `--allow-source-mismatch` for database backups. Previously
+  we set this to allow use of a dynamic temporary directory for each backup.
+  However, this also then allows backups to be overwritten from any host with
+  the same configuration. Instead, database dumps are now always sent to the
+  same path (which will be wiped and recreated each time) and duplicity will
+  fail if the backup source (path or host) has changed at a given destination.
+* Extracted backup command generation from the template to a custom helper,
   and refactored specs for the configure_backup recipe to stub the helper
   and reflect the new responsibilities. This allows for clearer and more
   rigorous specification of individual commands rather than having all the

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Other attributes are available to provide more control - see the attributes file
 
 Configuring for backup to S3
 ----------------------------
-Our usual strategy is to backup to an S3 bucket for the project, with separate paths in the bucket for the database and file backups. If there
-are multiple servers with file backups then we'll use a different destination path for each role - but usually we're only interested in uploaded
-user content, custom instance configuration and databases as everything else on the instance is provisioned from source control.
+Our usual strategy is to backup to an S3 bucket for the project, with separate paths
+in the bucket for each instance, and separate paths below that for the database and
+file backups.
 
 To get this working:
 ### Create an S3 bucket for the backups
@@ -110,9 +110,9 @@ To get this working:
 Create a bucket on EC2 and store the destination in your role attributes. For a bucket `my-app-backup` you'll want to set:
 
 ```ruby
-node.default['duplicity']['file_destination'] = 's3+http://my-app-backup/files'
-node.default['duplicity']['db_destination'] = 's3+http://my-app-backup/database'
-node.default['duplicity']['pg_destination'] = 's3+http://my-app-backup/pg_database'
+node.default['duplicity']['file_destination'] = 's3+http://my-app-backup/'+node['fqdn']+'/files'
+node.default['duplicity']['db_destination'] = 's3+http://my-app-backup/'+node['fqdn']+'/database'
+node.default['duplicity']['pg_destination'] = 's3+http://my-app-backup/'+node['fqdn']+'/pg_database'
 ```
 
 **We default to setting the --s3-european-buckets flag for duplicity. This should work with buckets outside the EU as well, but

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,9 @@ default['duplicity']['src_url'] = 'https://code.launchpad.net/duplicity/0.7-seri
 # local directory to place the source in
 default['duplicity']['src_dir'] = '/usr/local/src'
 
+# Local directory path to dump database files for backup
+default['duplicity']['dump_base_dir'] = '/var/duplicity/sources'
+
 # globbing patterns for file backup
 default['duplicity']['globbing_file_patterns'] = node['duplicity']['globbing_file_patterns'] || {}
 

--- a/templates/default/backup.sh.erb
+++ b/templates/default/backup.sh.erb
@@ -18,10 +18,15 @@ echo "Loading credentials and environment"
 source /etc/duplicity/environment.sh
 
 <% if node['duplicity']['backup_mysql'] %>
-echo "Creating mysql database dump"
+### mysql backup ###
+<%=@commands.export_dump_dir('MYSQL_DUMP_DIR', 'mysql_backup') %>
 
-# Create temp dir that only we can see
-MYSQLTMPDIR="$(mktemp -d)"
+echo "Creating mysql database dump in $MYSQL_DUMP_DIR"
+if [ -d $MYSQL_DUMP_DIR ]; then
+  (>&2 echo "CAUTION: $MYSQL_DUMP_DIR exists and will be wiped")
+fi
+
+<%=@commands.prepare_dump_dir('$MYSQL_DUMP_DIR') %>
 
 DBS="$(mysql --defaults-file=/etc/duplicity/mysql.cnf -h localhost -Bse 'show databases')"
 FOUND_DBS=""
@@ -37,7 +42,7 @@ do
       SCHEMA_BACKUP_FLAGS=""
     fi
 
-    <%=@commands.mysqldump('$db', '$MYSQLTMPDIR/mysql-$db.sql.gz') %>
+    <%=@commands.mysqldump('$db', '$MYSQL_DUMP_DIR/mysql-$db.sql.gz') %>
   fi
 done
 if [ -z "$FOUND_DBS" ]; then
@@ -47,9 +52,10 @@ if [ -z "$FOUND_DBS" ]; then
 fi
 
 echo "Backing up mysql database dump"
-<%=@commands.duplicity_backup_dir('$MYSQLTMPDIR', 'mysql_backup') %>
+<%=@commands.duplicity_backup_dir('$MYSQL_DUMP_DIR', 'mysql_backup') %>
 
-rm -rf "$MYSQLTMPDIR"
+echo "Removing local dump working directory"
+<%=@commands.remove_dump_dir('$MYSQL_DUMP_DIR') %>
 
 echo "Cleaning old mysql full database backups"
 <%=@commands.duplicity_remove_all_but_n_full('mysql_backup') %>
@@ -58,18 +64,21 @@ echo "Cleaning old mysql full database backups"
 
 <% if node['duplicity']['backup_postgresql'] %>
 ### PostgreSQL backup ###
+<%=@commands.export_dump_dir('PG_DUMP_DIR', 'pg_backup') %>
+if [ -d PG_DUMP_DIR ]; then
+  (>&2 echo "CAUTION: $PG_DUMP_DIR exists and will be wiped")
+fi
 
-echo "Creating postgresql database dump"
+echo "Creating postgresql database dump in $PG_DUMP_DIR"
+<%=@commands.prepare_dump_dir('$PG_DUMP_DIR') %>
 
-# Create temp dir that only we can see
-POSTGRESTMPDIR="$(mktemp -d)"
-
-<%=@commands.pg_dumpall('$POSTGRESTMPDIR/pgdump.sql.gz') %>
+<%=@commands.pg_dumpall('$PG_DUMP_DIR/pgdump.sql.gz') %>
 
 echo "Backing up postgresql database dump"
-<%=@commands.duplicity_backup_dir('$POSTGRESTMPDIR', 'pg_backup') %>
+<%=@commands.duplicity_backup_dir('$PG_DUMP_DIR', 'pg_backup') %>
 
-rm -rf "$POSTGRESTMPDIR"
+echo "Removing local dump working directory"
+<%=@commands.remove_dump_dir('$PG_DUMP_DIR') %>
 
 echo "Cleaning old postgresql full database backups"
 <%=@commands.duplicity_remove_all_but_n_full('pg_backup') %>


### PR DESCRIPTION
…-mismatch`

The database dump will now always go to the same location on the local
instance, which will be provisioned as required. This allows us to
drop --allow-source-mismatch and add protection against two instances
with the same provisioning fighting to overwrite each other's backups
(eg during a migration).