### PR TITLE
[BREAKING] Use consistent archive directory for all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* [BREAKING] Consistently use the **same** archive directory for every user.
+  Previously we were falling back to the default $HOME/.cache/duplicity but
+  this causes hassle when running occasional restore / backup manually. If you
+  deploy this to an existing instance, duplicity will have to fully re-sync its
+  local cached manifests and signatures on the next run. You can avoid this by
+  manually moving /root/.cache/duplicity to /var/duplicity/archive on the first
+  deployment.
 * [BREAKING] Disable `--allow-source-mismatch` for database backups. Previously
   we set this to allow use of a dynamic temporary directory for each backup.
   However, this also then allows backups to be overwritten from any host with

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,9 @@ default['duplicity']['src_url'] = 'https://code.launchpad.net/duplicity/0.7-seri
 # local directory to place the source in
 default['duplicity']['src_dir'] = '/usr/local/src'
 
+# Local directory path to the local archives for each job used to manage local signatures etc
+default['duplicity']['archive_dir'] = '/var/duplicity/archive'
+
 # Local directory path to dump database files for backup
 default['duplicity']['dump_base_dir'] = '/var/duplicity/sources'
 

--- a/libraries/command_builder.rb
+++ b/libraries/command_builder.rb
@@ -159,7 +159,7 @@ module Ingenerator
           '--force',
           "--name #{backup_name}"
         ]
-        parts.concat(duplicity_s3_options)
+        parts.concat(duplicity_common_options)
         parts.push('"' + job_destination(backup_name) + '"')
         format_command(parts)
       end
@@ -218,7 +218,7 @@ module Ingenerator
           "--full-if-older-than #{full_if_older_than}",
           "--name #{backup_name}"
         ]
-        parts.concat(duplicity_s3_options)
+        parts.concat(duplicity_common_options)
         parts.concat(extra_options)
         parts.push('"' + source_path + '"')
         parts.push('"' + job_destination(backup_name) + '"')
@@ -226,12 +226,15 @@ module Ingenerator
       end
 
       ##
-      # The S3-related command options relevant to all duplicity commands
+      # The options relevant to all duplicity commands
       #
       # @return [String]
       #
-      def duplicity_s3_options
-        options = ['--s3-use-new-style']
+      def duplicity_common_options
+        options = [
+          '--archive-dir="'+require_attribute!('duplicity.archive_dir')+'"',
+          '--s3-use-new-style'
+        ]
         if @node['duplicity']['s3-european-buckets']
           options << '--s3-european-buckets'
         end

--- a/recipes/configure_backup.rb
+++ b/recipes/configure_backup.rb
@@ -49,6 +49,14 @@ directory "/etc/duplicity" do
   group  "root"
 end
 
+directory node['duplicity']['archive_dir'] do
+  action :create
+  recursive true
+  mode   0o700
+  owner  'root'
+  group  'root'
+end
+
 # The list of files to include or exclude
 template "/etc/duplicity/globbing_file_list" do
   action :create

--- a/spec/recipes/configure_backup_spec.rb
+++ b/spec/recipes/configure_backup_spec.rb
@@ -27,6 +27,15 @@ describe 'duplicity-backup::configure_backup' do
     )
   end
 
+  it 'creates a private duplicity archive directory' do
+    expect(chef_run).to create_directory('/var/duplicity/archive').with(
+      owner: 'root',
+      group: 'root',
+      recursive: true,
+      mode: 0o700
+    )
+  end
+
   describe 'creates a backup file list' do
     it 'writes the filelist with restricted permissions' do
       expect(chef_run).to create_template('/etc/duplicity/globbing_file_list').with(


### PR DESCRIPTION
The local archive directory is now specified for all duplicity commands, rather than being defaulted to $HOME/.cache/duplicity. You may need to move old signatures etc to the new location if you plan to deploy this to an existing instance.


