### PR TITLE
Add `PROCESS` privilege to mysqldump user now required by mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 4.1.2 (2020-08-01)
+
+* [UPSTREAM BUG] Mysql >= 5.7.31 introduces a new requirement for the backup user to have the `PROCESS` privilege :
+  backups will fail without it. https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html and 
+  https://bugs.mysql.com/bug.php?id=100219.
+
 ## 4.1.1 (2019-09-11)
 
 * [UPSTREAM BUG] Workaround for https://github.com/poise/poise-python/issues/146 which causes pip install to fail on

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache-2.0'
 chef_version '>=12.18.31'
 description 'Installs and configures duplicity for remote backup'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.1.1'
+version '4.1.2'
 issues_url 'https://github.com/ingenerator/chef-duplicity-backup/issues'
 source_url 'https://github.com/ingenerator/chef-duplicity-backup'
 

--- a/recipes/backup_mysql_user.rb
+++ b/recipes/backup_mysql_user.rb
@@ -33,7 +33,7 @@ if node['duplicity']['backup_mysql'] then
     connection    root_connection
     host          'localhost'
     password      node['duplicity']['mysql']['password']
-    privileges    ['SELECT', 'SHOW VIEW', 'TRIGGER', 'LOCK TABLES', 'EVENT']
+    privileges    ['PROCESS', 'SELECT', 'SHOW VIEW', 'TRIGGER', 'LOCK TABLES', 'EVENT']
   end
   
 end

--- a/spec/recipes/backup_mysql_user_spec.rb
+++ b/spec/recipes/backup_mysql_user_spec.rb
@@ -32,7 +32,7 @@ describe 'duplicity-backup::backup_mysql_user' do
     it "should grant global read-only backup privileges to the user" do
       expect(chef_run).to grant_mysql_database_user('backup').with(
         :database_name  => nil,
-        :privileges     => ['SELECT', 'SHOW VIEW', 'TRIGGER', 'LOCK TABLES', 'EVENT']
+        :privileges     => ['PROCESS', 'SELECT', 'SHOW VIEW', 'TRIGGER', 'LOCK TABLES', 'EVENT']
       )
     end
 


### PR DESCRIPTION
The mysql 5.7.31 maintenance release introduces a requirement for
the backup user to have the PROCESS privilege or the command will
fail.