### PR TITLE
Pin to a 2.7-compatible URL for get-pip.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 4.1.3 (2021-04-02)
+
+* [BUG] Pin the pypi get_pip URL for python 2.7 (pypa is evidently now 
+  returning a newer / incompatible version by default)
+
 # 4.1.2 (2020-08-01)
 
 * [UPSTREAM BUG] Mysql >= 5.7.31 introduces a new requirement for the backup user to have the `PROCESS` privilege :

--- a/recipes/install_duplicity.rb
+++ b/recipes/install_duplicity.rb
@@ -26,7 +26,7 @@ python_runtime '2.7' do
   # the internal check to see if the url needs to be switched to a python 2.6 compatible one. That in turn avoids
   # poise-python attempting to parse an operating system package version as a gem version string, which currently
   # throws an exception as the debian python version 2.7.15+ is not a valid gem version.
-  get_pip_url 'https://bootstrap.pypa.io/get-pip.py#skip-poise-python-2.6-check'
+  get_pip_url 'https://bootstrap.pypa.io/pip/2.7/get-pip.py#skip-poise-python-2.6-check'
 end
 python_package 'lockfile'
 python_package 'fasteners'

--- a/spec/recipes/install_duplicity_spec.rb
+++ b/spec/recipes/install_duplicity_spec.rb
@@ -13,7 +13,7 @@ describe 'duplicity-backup::install_duplicity' do
 
   it "installs python 2 with pip" do
     expect(chef_run).to install_python_runtime('2.7').with(
-      get_pip_url: 'https://bootstrap.pypa.io/get-pip.py#skip-poise-python-2.6-check',
+      get_pip_url: 'https://bootstrap.pypa.io/pip/2.7/get-pip.py#skip-poise-python-2.6-check',
       pip_version: true,
       setuptools_version: true
     )


### PR DESCRIPTION
Seems like pypa is now serving a version that needs python 3.6,
pin to the older release.